### PR TITLE
1.3.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,9 @@ Version 1.3.3
 [*]Added new red sandstone desert pyramids which can spawn in outback and badlands.
 [*]Added the ability to double click biomes in the biome configuration menu to toggle whether they are enabled.
 [*]Changed world configuration to have deco generation enabled by default if deco is also installed. Deco generation may still be disabled if you wish.
-[*]Changed world configuration so that enabling deco automatically enables all deco exclusive biomes. Previously it was possible to enable deco but then not get deco biomes becaause you had to specifically re-enable them.
+[*]Changed world configuration so that enabling deco automatically enables all deco exclusive biomes. Previously it was possible to enable deco but then not get deco biomes because you had to specifically re-enable them.
 [*]Fixed an issue where frozen springs, plains, temperate forest, and patagonia were not properly generating reeds.
+[*]Fixed an issue where the game would crash if spaces were present in the generator options string.
 [/list]
 
 Version 1.3.2

--- a/src/minecraft/net/minecraft/src/BTAWorldConfigurationInfo.java
+++ b/src/minecraft/net/minecraft/src/BTAWorldConfigurationInfo.java
@@ -81,7 +81,7 @@ public class BTAWorldConfigurationInfo {
 		}
 		else {
 			//Ignores whitespace
-			infoString = infoString.replace("\\s", "");
+			infoString = infoString.replace(" ", "");
 			
 			String[] infoSplit = infoString.split(";");
 			

--- a/src/minecraft_server/net/minecraft/src/BTAWorldConfigurationInfo.java
+++ b/src/minecraft_server/net/minecraft/src/BTAWorldConfigurationInfo.java
@@ -81,7 +81,7 @@ public class BTAWorldConfigurationInfo {
 		}
 		else {
 			//Ignores whitespace
-			infoString = infoString.replace("\\s", "");
+			infoString = infoString.replace(" ", "");
 			
 			String[] infoSplit = infoString.split(";");
 			


### PR DESCRIPTION
- Added new red sandstone desert pyramids which can spawn in outback and badlands.
- Added the ability to double click biomes in the biome configuration menu to toggle whether they are enabled.
- Changed world configuration to have deco generation enabled by default if deco is also installed. Deco generation may still be disabled if you wish.
- Changed world configuration so that enabling deco automatically enables all deco exclusive biomes. Previously it was possible to enable deco but then not get deco biomes because you had to specifically re-enable them.
- Fixed an issue where frozen springs, plains, temperate forest, and patagonia were not properly generating reeds.
- Fixed an issue where the game would crash if spaces were present in the generator options string.